### PR TITLE
update ffmpeg-for-homebridge to 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "ip": "^1.1.5",
     "pbf": "^3.2.1",
     "axios": "^0.19.2",
-    "ffmpeg-for-homebridge": "^0.0.4"
+    "ffmpeg-for-homebridge": "^0.0.5"
   },
   "devDependencies": {
     "@types/ip": "^1.1.0",


### PR DESCRIPTION
This was just compiled this morning. I don't think it has been released to npm yet. Once it has you could merge or close and change yourself.