### PR TITLE
Ensure chrome is installed on x64 linux as well

### DIFF
--- a/src/postinstall.ts
+++ b/src/postinstall.ts
@@ -95,17 +95,18 @@ async function main() {
 function canUseBundledChromium() {
   switch (os.platform()) {
     case 'linux': {
-      // except on Alpine Linux
-      if (fs.existsSync('/etc/alpine-release')) {
-        return false;
-      }
-      return true;
+      // linux requires extra dependencies to be installed to run the bundled version of chrome
+      // it's safer to just install chromium using the system package manager
+      return false;
     }
     case 'win32': {
       return true;
     }
     case 'darwin': {
       return true;
+    }
+    default: {
+      return false;
     }
   }
 }


### PR DESCRIPTION
Linux requires extra dependencies to be installed to run the bundled version of chrome, it's going to be more reliable to just install chromium using the system package manager.