### PR TITLE
Correct random device ID

### DIFF
--- a/src/nest/streamer.ts
+++ b/src/nest/streamer.ts
@@ -26,7 +26,7 @@ enum StreamQuality {
  * @returns {string} The random device id
  */
 const generateDeviceId = (): string => {
-  return 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'.replace('x', () => {
+  return 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx'.replace(/x/g, () => {
     return Math.floor(Math.random() * 16).toString(16);
   });
 };


### PR DESCRIPTION
Corrected replace function to scan entire string when generating device ID rather than just the first character