### PR TITLE
updateAuthentication support for "Nest"

### DIFF
--- a/src/nest/streamer.ts
+++ b/src/nest/streamer.ts
@@ -276,9 +276,14 @@ export class NexusStreamer {
    * Update the socket authentication with the new access token
    */
   private updateAuthentication(): void {
-    const token = {
-      olive_token: this.accessToken,
-    };
+    var token = {};
+    if (nestAuth) {
+      // Re-authorisation using "Nest" token
+      token = {session_token: accessToken};
+    } else {
+      // Re-authorisation using "Google" token
+      token = {olive_token: accessToken};
+    }
     const tokenContainer = new Pbf();
     AuthorizeRequest.write(token, tokenContainer);
     const tokenBuffer = tokenContainer.finish();

--- a/src/nest/streamer.ts
+++ b/src/nest/streamer.ts
@@ -277,12 +277,12 @@ export class NexusStreamer {
    */
   private updateAuthentication(): void {
     var token = {};
-    if (nestAuth) {
+    if (this.nestAuth) {
       // Re-authorisation using "Nest" token
-      token = {session_token: accessToken};
+      token = {session_token: this.accessToken};
     } else {
       // Re-authorisation using "Google" token
-      token = {olive_token: accessToken};
+      token = {olive_token: this.accessToken};
     }
     const tokenContainer = new Pbf();
     AuthorizeRequest.write(token, tokenContainer);


### PR DESCRIPTION
Original code only supported re-authorisation using a "Google" token. Updated function to support both "Nest" and "Google" tokens when a re-authorisation is requested