### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   ],
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^0.0.19",
-    "axios": "^0.27.2",
+    "axios": ">=1.2.1",
     "base64url": "^3.0.1",
     "execa": "^5.1.1",
     "ffmpeg-for-homebridge": "^0.1.4",


### PR DESCRIPTION
Bumped axios dependancy 1.2.1 or later to ensure regression error in axios 1.2.1 isn't encountered